### PR TITLE
Fix editor spacing when block is empty

### DIFF
--- a/src/editor.css
+++ b/src/editor.css
@@ -12,7 +12,7 @@
 }
 
 .wp-block[data-type="sortabrilliant/postscript"] .wp-block-post-script {
-	padding-top: 10px;
+	padding: 30px 0 5px;
 }
 
 .wp-block[data-type="sortabrilliant/postscript"] .wp-block-post-script:before {


### PR DESCRIPTION
This PR addresses the styling issue discussed [here](https://github.com/sortabrilliant/ps/pull/6#issuecomment-578491725) by adding extra spacing to the block in the editor view.

**Empty:**
![image](https://user-images.githubusercontent.com/1713699/73307583-c5034780-421e-11ea-8f8b-3877a63ec4a5.png)

**With content:**
![image](https://user-images.githubusercontent.com/1713699/73307563-b74dc200-421e-11ea-98dc-5840a5499122.png)
